### PR TITLE
Improve mobile layout

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -40,7 +40,7 @@
     </button>
   </div>
 
-  <div class="w-full px-3 py-6 max-w-screen-lg mx-auto mt-8 p-6 bg-white dark:bg-gray-800 rounded-xl shadow-lg">
+  <div class="w-full px-3 py-4 sm:py-6 max-w-screen-lg mx-auto mt-6 sm:mt-8 p-4 sm:p-6 bg-white dark:bg-gray-800 rounded-xl shadow-lg">
     <h1 class="text-xl sm:text-2xl font-semibold mb-6 text-center">Adminbereich – Rischis Kiosk</h1>
 
     <!-- Produkt hinzufügen -->

--- a/buzzer.html
+++ b/buzzer.html
@@ -8,7 +8,7 @@
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
 </head>
 <body class="flex flex-col items-center justify-center min-h-screen bg-green-100 text-green-900 font-sans space-y-6 px-4">
-  <h1 class="text-3xl font-bold mt-8">🔔 Buzzer</h1>
+  <h1 class="text-3xl font-bold mt-6 sm:mt-8">🔔 Buzzer</h1>
   <audio id="buzz-sound" src="buzz.wav" preload="auto"></audio>
 
   <p id="status" class="text-xl font-semibold"></p>
@@ -26,7 +26,7 @@
   </div>
 
   <!-- Punktestand-Tabelle -->
-  <div id="scoreboard" class="w-full max-w-xs sm:max-w-md mt-8 bg-white shadow rounded p-4 text-sm sm:text-base">
+  <div id="scoreboard" class="w-full max-w-xs sm:max-w-md mt-8 bg-white shadow rounded p-4 text-sm sm:text-base overflow-x-auto">
     <h2 class="text-lg sm:text-xl font-bold mb-4 text-center">🏆 Punktestand</h2>
     <table class="w-full table-auto text-left">
       <thead>

--- a/dashboard.html
+++ b/dashboard.html
@@ -24,7 +24,7 @@
   </style>
 </head>
 <body class="flex items-center justify-center h-screen text-green-900">
-  <div class="text-center p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect space-y-6">
+  <div class="text-center p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect space-y-6">
     <h1 class="text-3xl sm:text-4xl font-bold">🚀 Was willst du tun?</h1>
     <div class="flex flex-col sm:flex-row gap-6 justify-center items-center mt-6">
       <a href="shop.html" class="bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   </style>
 </head>
 <body class="text-green-900 relative">
-  <div class="w-full px-3 py-2 max-w-screen-sm mx-auto mt-20 p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
+  <div class="w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
     <h1 class="text-3xl sm:text-4xl font-bold mb-4 text-center text-green-800">
       Rischis Kiosk<br><span class="text-lg sm:text-xl sm:text-2xl">Let’s blaze & buy</span>
     </h1>

--- a/shop.html
+++ b/shop.html
@@ -30,7 +30,7 @@
   </style>
 </head>
 <body class="text-green-900 relative">
-  <div class="w-full px-3 py-2 max-w-screen-sm mx-auto mt-20 p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
+  <div class="w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
 
     <div id="loader" class="fixed inset-0 bg-white bg-opacity-70 flex items-center justify-center hidden z-50">
       <div class="animate-spin rounded-full h-16 w-16 border-t-4 border-green-500"></div>


### PR DESCRIPTION
## Summary
- tweak padding and margin for smaller screens
- add overflow handling for scoreboard

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_683e131f7ecc83209d34dedec11743c3