### PR TITLE
Improve mobile support

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Adminbereich – Rischis Kiosk</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -29,6 +29,14 @@
   .dark ::placeholder {
     color: #9ca3af; /* Tailwind gray-400 */
   }
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
 </style>
 
 <body class="bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-white">

--- a/shop.html
+++ b/shop.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Rischis Kiosk – Shop</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
@@ -27,6 +27,14 @@
       backdrop-filter: blur(14px);
       background-color: rgba(255, 255, 255, 0.88);
     }
+  body {
+    max-width: 100vw;
+    overflow-x: hidden;
+    padding-top: env(safe-area-inset-top);
+    padding-right: env(safe-area-inset-right);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+  }
   </style>
 </head>
 <body class="text-green-900 relative">


### PR DESCRIPTION
## Summary
- adjust viewport meta tag for iPhone safe area
- add body style with safe area padding and overflow control
- replicate these mobile tweaks in the shop

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_683e1592b8f08320906686fd3a566ee7