### PR TITLE
Fix mobile layout for admin page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -142,7 +142,7 @@ body {
       <button onclick="togglePurchases()" class="w-full text-left bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 px-4 py-3 rounded-lg font-semibold text-gray-800 dark:text-white transition">
         Käufe anzeigen / ausblenden
       </button>
-      <div id="purchase-container" class="mt-4 hidden max-h-80 overflow-y-auto border rounded-lg bg-gray-50 dark:bg-gray-700 p-4">
+      <div id="purchase-container" class="mt-4 hidden max-h-80 overflow-y-auto overflow-x-auto border rounded-lg bg-gray-50 dark:bg-gray-700 p-4">
         <ul id="purchase-history" class="space-y-2 text-sm text-gray-700 dark:text-white"></ul>
         <button onclick="loadMorePurchases()" class="mt-4 text-blue-600 hover:underline text-sm">Weitere anzeigen</button>
       </div>
@@ -265,14 +265,14 @@ const { error } = await supabase.from('products').insert({
           <p class="text-sm text-gray-600 sm:ml-4">Kategorie: <strong>${p.category || '-'}</strong></p>
         </div>
       </div>
-      <div class="flex gap-3 mt-2 sm:mt-0 sm:items-center w-full sm:w-auto">
-        <button onclick="toggleAvailability('${p.id}', ${p.available})" class="bg-yellow-500 text-white px-4 py-2 rounded-md shadow-md hover:bg-yellow-600 focus:outline-none">
+      <div class="flex flex-col sm:flex-row gap-3 mt-2 sm:mt-0 sm:items-center w-full sm:w-auto">
+        <button onclick="toggleAvailability('${p.id}', ${p.available})" class="bg-yellow-500 text-white px-4 py-2 rounded-md shadow-md hover:bg-yellow-600 focus:outline-none w-full sm:w-auto">
           ${p.available ? 'Verstecken' : 'Anzeigen'}
         </button>
-        <button onclick="editProduct('${p.id}')" class="bg-blue-600 text-white px-4 py-2 rounded-md shadow-md hover:bg-blue-700 focus:outline-none">
+        <button onclick="editProduct('${p.id}')" class="bg-blue-600 text-white px-4 py-2 rounded-md shadow-md hover:bg-blue-700 focus:outline-none w-full sm:w-auto">
           Bearbeiten
         </button>
-        <button onclick="deleteProduct('${p.id}')" class="bg-red-600 text-white px-4 py-2 rounded-md shadow-md hover:bg-red-700 focus:outline-none">
+        <button onclick="deleteProduct('${p.id}')" class="bg-red-600 text-white px-4 py-2 rounded-md shadow-md hover:bg-red-700 focus:outline-none w-full sm:w-auto">
           Löschen
         </button>
       </div>
@@ -348,13 +348,13 @@ const { error } = await supabase.from('products').insert({
 
     async function loadUserPasswords() {
       const { data } = await supabase.from('users').select('id, email, name');
-      document.getElementById('user-manage-list').innerHTML = data.map(u => ` 
+        document.getElementById('user-manage-list').innerHTML = data.map(u => `
         <li>
-          <div class="flex items-center">
-            <input type="text" id="name-${u.id}" class="border px-2 mr-2" value="${u.name}" placeholder="Neuer Name" />
-            <button onclick="changeUserName('${u.id}')" class="bg-blue-600 text-white px-2 ml-1 rounded hover:bg-blue-700">Name ändern</button>
-            <input type="password" id="pw-${u.id}" class="border px-2 ml-3" placeholder="Neues Passwort" />
-            <button onclick="changeUserPassword('${u.id}')" class="bg-yellow-600 text-white px-2 ml-1 rounded hover:bg-yellow-700">Passwort ändern</button>
+          <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2">
+            <input type="text" id="name-${u.id}" class="border px-2 w-full sm:w-auto" value="${u.name}" placeholder="Neuer Name" />
+            <button onclick="changeUserName('${u.id}')" class="bg-blue-600 text-white px-2 rounded hover:bg-blue-700 w-full sm:w-auto">Name ändern</button>
+            <input type="password" id="pw-${u.id}" class="border px-2 w-full sm:w-auto" placeholder="Neues Passwort" />
+            <button onclick="changeUserPassword('${u.id}')" class="bg-yellow-600 text-white px-2 rounded hover:bg-yellow-700 w-full sm:w-auto">Passwort ändern</button>
           </div>
         </li>`).join('');
     }
@@ -375,14 +375,14 @@ const { error } = await supabase.from('products').insert({
 
     async function loadUserBalances() {
       const { data } = await supabase.from('users').select('id, name, balance');
-      document.getElementById('balance-control-list').innerHTML = data.map(u => {
+        document.getElementById('balance-control-list').innerHTML = data.map(u => {
         const balanceColor = u.balance < 0 ? 'text-red-600 font-bold' : 'text-black';
         return `
-          <li>
-            ${u.name}: <span class="${balanceColor}">${u.balance.toFixed(2)} €</span>
-            <input type="number" id="bal-${u.id}" class="w-24 border px-2 ml-2" step="0.01" />
-            <button onclick="updateBalance('${u.id}', 'add')" class="bg-green-600 text-white px-2 ml-1 rounded hover:bg-green-700">Hinzufügen</button>
-            <button onclick="updateBalance('${u.id}', 'subtract')" class="bg-red-600 text-white px-2 ml-1 rounded hover:bg-red-700">Abziehen</button>
+          <li class="flex flex-col sm:flex-row items-start sm:items-center gap-2">
+            <div>${u.name}: <span class="${balanceColor}">${u.balance.toFixed(2)} €</span></div>
+            <input type="number" id="bal-${u.id}" class="w-full sm:w-24 border px-2" step="0.01" />
+            <button onclick="updateBalance('${u.id}', 'add')" class="bg-green-600 text-white px-2 rounded hover:bg-green-700 w-full sm:w-auto">Hinzufügen</button>
+            <button onclick="updateBalance('${u.id}', 'subtract')" class="bg-red-600 text-white px-2 rounded hover:bg-red-700 w-full sm:w-auto">Abziehen</button>
           </li>`;
       }).join('');
     }


### PR DESCRIPTION
## Summary
- add horizontal scroll on purchase history
- make product action buttons wrap on small screens
- stack user management inputs and balance controls vertically on narrow screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683e178f9fd883209b411a2381a4f5db