### PR TITLE
Add Mentos feeding tracker

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -30,6 +30,7 @@
     <div class="flex flex-col sm:flex-row gap-6 justify-center items-center mt-6">
       <a href="shop.html" class="bg-green-600 hover:bg-green-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛒 Zum Kiosk</a>
       <a href="buzzer.html" class="bg-yellow-500 hover:bg-yellow-600 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🔔 Buzzern</a>
+      <a href="mentos.html" class="bg-purple-600 hover:bg-purple-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🐱 Mentos</a>
       <a id="admin-btn" href="admin.html" class="hidden bg-red-600 hover:bg-red-700 text-white text-lg font-bold py-3 px-6 rounded-full shadow-lg">🛠️ Adminbereich</a>
     </div>
   </div>

--- a/mentos.html
+++ b/mentos.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>Mentos – Fütterungstracker</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+  </script>
+  <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Comfortaa&family=Rock+Salt&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Comfortaa', cursive;
+      background: radial-gradient(circle at top left, #c7f9cc, #80ed99 40%, #57cc99 90%, #38a3a5);
+    }
+    h1, h2 { font-family: 'Rock Salt', cursive; }
+    .kiffer-shadow { box-shadow: 0 15px 35px rgba(22, 163, 74, 0.4); }
+    .glass-effect { backdrop-filter: blur(14px); background-color: rgba(255, 255, 255, 0.88); }
+  </style>
+</head>
+<body class="text-green-900 relative dark:bg-gray-900 dark:text-white">
+  <div class="fixed top-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
+      🌙 / ☀️
+    </button>
+  </div>
+
+  <div class="w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
+    <h1 class="text-3xl sm:text-4xl font-bold mb-6 text-center text-green-800">Mentos 🐱</h1>
+    <h2 class="text-xl text-center mb-4">Letzte Fütterung vor: <span id="last-feed">-</span></h2>
+
+    <div class="flex flex-col sm:flex-row justify-center gap-4 mb-6">
+      <button id="btn-nass" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full shadow">🐟 Nassfutter gegeben</button>
+      <button id="btn-trocken" class="bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full shadow">🥣 Trockenfutter gegeben</button>
+    </div>
+
+    <div class="overflow-x-auto">
+      <table class="table-auto w-full text-center text-sm">
+        <thead>
+          <tr>
+            <th class="px-2 py-1 border-b">Zeit</th>
+            <th class="px-2 py-1 border-b">Futterart</th>
+            <th class="px-2 py-1 border-b">Gefüttert von</th>
+          </tr>
+        </thead>
+        <tbody id="feedings-body"></tbody>
+      </table>
+    </div>
+
+    <div class="text-center mt-8">
+      <a href="dashboard.html" class="inline-block bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full shadow">
+        ⬅️ Zurück zum Dashboard
+      </a>
+    </div>
+  </div>
+
+  <script>
+    function toggleDarkMode() {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('darkMode', isDark ? 'true' : 'false');
+    }
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark');
+    }
+
+    const supabase = window.supabase.createClient(
+      "https://izkuiqjhzeeirmcikbef.supabase.co",
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0"
+    );
+
+    let countdownInterval;
+
+    async function loadFeedings() {
+      const { data, error } = await supabase
+        .from('mentos_feedings')
+        .select('zeitstempel,futterart,gefuettert_von')
+        .order('zeitstempel', { ascending: false })
+        .limit(20);
+      if (error) return;
+      updateTable(data);
+      if (data.length) startCountdown(new Date(data[0].zeitstempel));
+    }
+
+    function updateTable(entries) {
+      const body = document.getElementById('feedings-body');
+      body.innerHTML = entries.map(e => `
+        <tr>
+          <td class="px-2 py-1 border-b">${new Date(e.zeitstempel).toLocaleString()}</td>
+          <td class="px-2 py-1 border-b">${e.futterart}</td>
+          <td class="px-2 py-1 border-b">${e.gefuettert_von || ''}</td>
+        </tr>`).join('');
+    }
+
+    function startCountdown(time) {
+      clearInterval(countdownInterval);
+      function update() {
+        const diff = Date.now() - time.getTime();
+        const minutes = Math.floor(diff / 60000);
+        const seconds = Math.floor((diff % 60000) / 1000);
+        document.getElementById('last-feed').textContent = `${minutes}m ${seconds}s`;
+      }
+      update();
+      countdownInterval = setInterval(update, 1000);
+    }
+
+    async function addFeeding(type) {
+      const { data: auth } = await supabase.auth.getUser();
+      const name = auth?.user ? (auth.user.user_metadata?.name || auth.user.email.split('@')[0]) : null;
+      await supabase.from('mentos_feedings').insert({ futterart: type, gefuettert_von: name });
+      loadFeedings();
+    }
+
+    document.getElementById('btn-nass').addEventListener('click', () => addFeeding('Nassfutter'));
+    document.getElementById('btn-trocken').addEventListener('click', () => addFeeding('Trockenfutter'));
+
+    loadFeedings();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add permanent **Mentos** button on dashboard
- implement new `mentos.html` page for Mentos feeding tracking with dark mode support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f3dbf55dc8320b0072315e654712b