### PR TITLE
Implement clear history for Mentos feedings

### DIFF
--- a/mentos.html
+++ b/mentos.html
@@ -140,12 +140,17 @@
       document.getElementById('last-feed').textContent = '-';
     }
 
-    function clearFeedingDisplay() {
-      document.getElementById('feedings-body').innerHTML = '';
+    async function clearFeedingHistory() {
+      await supabase
+        .from('mentos_feedings')
+        .delete()
+        .gt('zeitstempel', '1900-01-01');
+      resetTimerDisplay();
+      loadFeedings();
     }
 
     resetTimerBtn.addEventListener('click', resetTimerDisplay);
-    clearHistoryBtn.addEventListener('click', clearFeedingDisplay);
+    clearHistoryBtn.addEventListener('click', clearFeedingHistory);
 
     loadFeedings();
   </script>


### PR DESCRIPTION
## Summary
- add new `clearFeedingHistory` function to remove all feeding entries from Supabase and refresh the display
- wire "Anzeige löschen" button to this new function

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f424b2f2c83208549eb492d7c2155