### PR TITLE
Fix admin dark mode

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -29,10 +29,6 @@
   .dark ::placeholder {
     color: #9ca3af; /* Tailwind gray-400 */
   }
-  /* Invert the entire interface when dark mode is active */
-  .dark {
-    filter: invert(1) hue-rotate(180deg);
-  }
   body {
     max-width: 100vw;
     overflow-x: hidden;


### PR DESCRIPTION
## Summary
- remove CSS filter that inverted all colours in the admin page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_683f465d4f688320b06c3d74aae37f9e