### PR TITLE
Ensure white text in admin dark mode

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -62,7 +62,7 @@
            required
            class="p-3 border rounded w-full shadow-sm 
                   bg-white text-black placeholder-gray-500
-                  dark:bg-gray-700 dark:text-white dark:placeholder-gray-400" />
+                  dark:bg-gray-700 dark:text-white dark:placeholder-white" />
 
     <input type="number" step="0.01"
            id="product-price"
@@ -70,7 +70,7 @@
            required
            class="p-3 border rounded w-full shadow-sm 
                   bg-white text-black placeholder-gray-500
-                  dark:bg-gray-700 dark:text-white dark:placeholder-gray-400" />
+                  dark:bg-gray-700 dark:text-white dark:placeholder-white" />
 
     <input type="number" step="0.01"
            id="product-purchase"
@@ -78,7 +78,7 @@
            required
            class="p-3 border rounded w-full shadow-sm 
                   bg-white text-black placeholder-gray-500
-                  dark:bg-gray-700 dark:text-white dark:placeholder-gray-400" />
+                  dark:bg-gray-700 dark:text-white dark:placeholder-white" />
 
     <input type="number"
            id="product-stock"
@@ -86,7 +86,7 @@
            required
            class="p-3 border rounded w-full shadow-sm 
                   bg-white text-black placeholder-gray-500
-                  dark:bg-gray-700 dark:text-white dark:placeholder-gray-400" />
+                  dark:bg-gray-700 dark:text-white dark:placeholder-white" />
   </div>
 
   <div>
@@ -241,7 +241,7 @@ const { error } = await supabase.from('products').insert({
         <hr class="my-3" />
         <p class="text-sm"><strong>Verkaufserlöse:</strong> ${totalRevenue.toFixed(2)} €</p>
         <p class="text-sm"><strong>Einkaufskosten:</strong> ${totalCost.toFixed(2)} €</p>
-        <p class="text-sm"><strong>Gewinn / Verlust:</strong> <span class="${profit >= 0 ? 'text-green-600' : 'text-red-600'}">${profit.toFixed(2)} €</span></p>
+        <p class="text-sm"><strong>Gewinn / Verlust:</strong> <span class="${profit >= 0 ? 'text-green-600 dark:text-white' : 'text-red-600 dark:text-white'}">${profit.toFixed(2)} €</span></p>
         <hr class="my-3" />
         <p class="text-sm"><strong>Gesamtsaldo aller Nutzer:</strong> ${totalBalance.toFixed(2)} €</p>`;
     }
@@ -260,9 +260,9 @@ const { error } = await supabase.from('products').insert({
       <div class="flex flex-col sm:flex-row items-start sm:items-center w-full">
         <h3 class="text-lg sm:text-xl font-semibold text-gray-800 dark:text-white mb-2 sm:mb-0 w-full sm:w-1/2">${p.name}</h3>
         <div class="flex flex-col sm:flex-row sm:ml-auto w-full sm:w-1/2">
-          <p class="text-sm text-gray-600 dark:text-gray-300 sm:ml-4">Preis: <strong>${p.price.toFixed(2)} €</strong></p>
-          <p class="text-sm text-gray-600 dark:text-gray-300 sm:ml-4">Bestand: <strong>${p.stock}</strong></p>
-          <p class="text-sm text-gray-600 dark:text-gray-300 sm:ml-4">Kategorie: <strong>${p.category || '-'}</strong></p>
+          <p class="text-sm text-gray-600 dark:text-white sm:ml-4">Preis: <strong>${p.price.toFixed(2)} €</strong></p>
+          <p class="text-sm text-gray-600 dark:text-white sm:ml-4">Bestand: <strong>${p.stock}</strong></p>
+          <p class="text-sm text-gray-600 dark:text-white sm:ml-4">Kategorie: <strong>${p.category || '-'}</strong></p>
         </div>
       </div>
       <div class="flex flex-col sm:flex-row gap-3 mt-2 sm:mt-0 sm:items-center w-full sm:w-auto">
@@ -376,7 +376,7 @@ const { error } = await supabase.from('products').insert({
     async function loadUserBalances() {
       const { data } = await supabase.from('users').select('id, name, balance');
         document.getElementById('balance-control-list').innerHTML = data.map(u => {
-        const balanceColor = u.balance < 0 ? 'text-red-600 font-bold' : 'text-black';
+        const balanceColor = u.balance < 0 ? 'text-red-600 dark:text-white font-bold' : 'text-black dark:text-white';
         return `
           <li class="flex flex-col sm:flex-row items-start sm:items-center gap-2">
             <div>${u.name}: <span class="${balanceColor}">${u.balance.toFixed(2)} €</span></div>


### PR DESCRIPTION
## Summary
- update dark mode placeholder colors
- ensure all stats and balance figures use white text in dark mode

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_683f49213bf48320ae85d52622024afd