### PR TITLE
Add dark mode toggle to all pages

### DIFF
--- a/buzzer.html
+++ b/buzzer.html
@@ -5,9 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Buzzer</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+  </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
 </head>
-<body class="flex flex-col items-center justify-center min-h-screen bg-green-100 text-green-900 font-sans space-y-6 px-4">
+<body class="flex flex-col items-center justify-center min-h-screen bg-green-100 text-green-900 font-sans space-y-6 px-4 dark:bg-gray-900 dark:text-white">
+  <div class="fixed top-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
+      🌙 / ☀️
+    </button>
+  </div>
   <h1 class="text-3xl font-bold mt-6 sm:mt-8">🔔 Buzzer</h1>
   <audio id="buzz-sound" src="buzz.wav" preload="auto"></audio>
 
@@ -53,6 +61,14 @@
   </div>
 
   <script>
+    function toggleDarkMode() {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('darkMode', isDark ? 'true' : 'false');
+    }
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark');
+    }
+
     const SUPABASE_URL = 'https://izkuiqjhzeeirmcikbef.supabase.co';
     const ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0';
     const SERVICE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0ODgwMDA5NCwiZXhwIjoyMDY0Mzc2MDk0fQ.yF2-AKGKcHFNpkIt-bg-YMhWjjLK74cLw6t3VfjDl8w';

--- a/dashboard.html
+++ b/dashboard.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Rischis Kiosk – Auswahl</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+  </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Comfortaa&family=Rock+Salt&display=swap" rel="stylesheet">
   <style>
@@ -24,7 +27,12 @@
     }
   </style>
 </head>
-<body class="flex items-center justify-center min-h-screen text-green-900">
+<body class="flex items-center justify-center min-h-screen text-green-900 dark:bg-gray-900 dark:text-white">
+  <div class="fixed top-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
+      🌙 / ☀️
+    </button>
+  </div>
   <div class="text-center p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect space-y-6">
     <h1 class="text-3xl sm:text-4xl font-bold">🚀 Was willst du tun?</h1>
     <div class="flex flex-col sm:flex-row gap-6 justify-center items-center mt-6">
@@ -36,6 +44,14 @@
   </div>
 
   <script>
+    function toggleDarkMode() {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('darkMode', isDark ? 'true' : 'false');
+    }
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark');
+    }
+
     const supabase = window.supabase.createClient(
       "https://izkuiqjhzeeirmcikbef.supabase.co",
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0"

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Rischis Kiosk – Login</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+  </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Comfortaa&family=Rock+Salt&display=swap" rel="stylesheet">
   <style>
@@ -32,7 +35,12 @@
     }
   </style>
 </head>
-<body class="text-green-900 relative">
+<body class="text-green-900 relative dark:bg-gray-900 dark:text-white">
+  <div class="fixed top-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
+      🌙 / ☀️
+    </button>
+  </div>
   <div class="w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
     <h1 class="text-3xl sm:text-4xl font-bold mb-4 text-center text-green-800">
       Rischis Kiosk<br><span class="text-lg sm:text-xl sm:text-2xl">Let’s blaze & buy</span>
@@ -61,6 +69,14 @@
   </div>
 
   <script>
+    function toggleDarkMode() {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('darkMode', isDark ? 'true' : 'false');
+    }
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark');
+    }
+
     const supabase = window.supabase.createClient(
       "https://izkuiqjhzeeirmcikbef.supabase.co",
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0"

--- a/shop.html
+++ b/shop.html
@@ -10,6 +10,9 @@
   <meta name="theme-color" content="#38a3a5">
   <title>Rischis Kiosk – Shop</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+  </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Comfortaa&family=Rock+Salt&display=swap" rel="stylesheet">
   <style>
@@ -61,7 +64,12 @@
   }
   </style>
 </head>
-<body class="text-green-900 relative">
+<body class="text-green-900 relative dark:bg-gray-900 dark:text-white">
+  <div class="fixed top-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
+      🌙 / ☀️
+    </button>
+  </div>
   <div class="shop-container w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
 
     <div id="loader" class="fixed inset-0 bg-white bg-opacity-70 flex items-center justify-center hidden z-50">
@@ -103,6 +111,14 @@
   </div>
 
   <script>
+    function toggleDarkMode() {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('darkMode', isDark ? 'true' : 'false');
+    }
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark');
+    }
+
     const supabase = window.supabase.createClient(
       "https://izkuiqjhzeeirmcikbef.supabase.co",
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0"


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode on pages outside the admin area
- add dark mode toggle button across the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f4a66769c8320a1c9350464a1f8ed