### PR TITLE
Improve dark mode support

### DIFF
--- a/buzzer.html
+++ b/buzzer.html
@@ -9,6 +9,24 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <style>
+    input, select, textarea {
+      background-color: white;
+      color: black;
+    }
+    ::placeholder {
+      color: #6b7280;
+    }
+    .dark input,
+    .dark select,
+    .dark textarea {
+      background-color: #374151;
+      color: white;
+    }
+    .dark ::placeholder {
+      color: #9ca3af;
+    }
+  </style>
 </head>
 <body class="flex flex-col items-center justify-center min-h-screen bg-green-100 text-green-900 font-sans space-y-6 px-4 dark:bg-gray-900 dark:text-white">
   <div class="fixed top-4 right-4 z-50">
@@ -34,7 +52,7 @@
   </div>
 
   <!-- Punktestand-Tabelle -->
-  <div id="scoreboard" class="w-full max-w-xs sm:max-w-md mt-8 bg-white shadow rounded p-4 text-sm sm:text-base overflow-x-auto">
+  <div id="scoreboard" class="w-full max-w-xs sm:max-w-md mt-8 bg-white shadow rounded p-4 text-sm sm:text-base overflow-x-auto dark:bg-gray-800">
     <h2 class="text-lg sm:text-xl font-bold mb-4 text-center">🏆 Punktestand</h2>
     <table class="w-full table-auto text-left">
       <thead>

--- a/dashboard.html
+++ b/dashboard.html
@@ -25,6 +25,25 @@
       backdrop-filter: blur(14px);
       background-color: rgba(255, 255, 255, 0.88);
     }
+    .dark .glass-effect {
+      background-color: rgba(31, 41, 55, 0.88);
+    }
+    input, select, textarea {
+      background-color: white;
+      color: black;
+    }
+    ::placeholder {
+      color: #6b7280;
+    }
+    .dark input,
+    .dark select,
+    .dark textarea {
+      background-color: #374151;
+      color: white;
+    }
+    .dark ::placeholder {
+      color: #9ca3af;
+    }
   </style>
 </head>
 <body class="flex items-center justify-center min-h-screen text-green-900 dark:bg-gray-900 dark:text-white">

--- a/index.html
+++ b/index.html
@@ -33,6 +33,25 @@
       backdrop-filter: blur(14px);
       background-color: rgba(255, 255, 255, 0.88);
     }
+    .dark .glass-effect {
+      background-color: rgba(31, 41, 55, 0.88);
+    }
+    input, select, textarea {
+      background-color: white;
+      color: black;
+    }
+    ::placeholder {
+      color: #6b7280;
+    }
+    .dark input,
+    .dark select,
+    .dark textarea {
+      background-color: #374151;
+      color: white;
+    }
+    .dark ::placeholder {
+      color: #9ca3af;
+    }
   </style>
 </head>
 <body class="text-green-900 relative dark:bg-gray-900 dark:text-white">

--- a/mentos.html
+++ b/mentos.html
@@ -18,6 +18,21 @@
     h1, h2 { font-family: 'Rock Salt', cursive; }
     .kiffer-shadow { box-shadow: 0 15px 35px rgba(22, 163, 74, 0.4); }
     .glass-effect { backdrop-filter: blur(14px); background-color: rgba(255, 255, 255, 0.88); }
+    .dark .glass-effect { background-color: rgba(31, 41, 55, 0.88); }
+    input, select, textarea {
+      background-color: white;
+      color: black;
+    }
+    ::placeholder {
+      color: #6b7280;
+    }
+    .dark input,
+    .dark select,
+    .dark textarea {
+      background-color: #374151;
+      color: white;
+    }
+    .dark ::placeholder { color: #9ca3af; }
   </style>
 </head>
 <body class="text-green-900 relative dark:bg-gray-900 dark:text-white">

--- a/shop.html
+++ b/shop.html
@@ -62,6 +62,25 @@
       font-size: 1.25rem;
     }
   }
+  .dark .glass-effect {
+    background-color: rgba(31, 41, 55, 0.88);
+  }
+  input, select, textarea {
+    background-color: white;
+    color: black;
+  }
+  ::placeholder {
+    color: #6b7280;
+  }
+  .dark input,
+  .dark select,
+  .dark textarea {
+    background-color: #374151;
+    color: white;
+  }
+  .dark ::placeholder {
+    color: #9ca3af;
+  }
   </style>
 </head>
 <body class="text-green-900 relative dark:bg-gray-900 dark:text-white">
@@ -72,7 +91,7 @@
   </div>
   <div class="shop-container w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
 
-    <div id="loader" class="fixed inset-0 bg-white bg-opacity-70 flex items-center justify-center hidden z-50">
+    <div id="loader" class="fixed inset-0 bg-white bg-opacity-70 flex items-center justify-center hidden z-50 dark:bg-gray-900 dark:bg-opacity-70">
       <div class="animate-spin rounded-full h-16 w-16 border-t-4 border-green-500"></div>
     </div>
 
@@ -199,7 +218,7 @@ async function loadCategories() {
     .filter(p => p.name.toLowerCase().includes(searchTerm))
     .forEach(product => {
       const li = document.createElement('li');
-      li.className = 'border-2 border-green-300 bg-white bg-opacity-80 p-4 rounded-xl shadow text-green-900';
+      li.className = 'border-2 border-green-300 bg-white bg-opacity-80 p-4 rounded-xl shadow text-green-900 dark:bg-gray-700 dark:text-white dark:border-gray-600';
 
       li.innerHTML = `
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
@@ -211,7 +230,7 @@ async function loadCategories() {
           </div>
           ${product.stock > 0 ? 
             `<div class="flex flex-col sm:flex-row items-center gap-2">
-              <input type="number" min="1" max="${product.stock}" value="1" id="qty-${product.id}" class="w-16 border-2 border-green-400 rounded px-2 py-1">
+              <input type="number" min="1" max="${product.stock}" value="1" id="qty-${product.id}" class="w-16 border-2 border-green-400 rounded px-2 py-1 dark:bg-gray-700 dark:text-white dark:border-gray-600">
               <button class="bg-green-700 text-white px-4 py-2 rounded-full shadow hover:bg-green-800 transition-all" onclick="buyProduct('${product.id}', 'qty-${product.id}', '${product.name}', ${product.price})">Kaufen</button>
             </div>` : ''
           }


### PR DESCRIPTION
## Summary
- update styling to support dark mode on all pages
- ensure dynamic product elements render correctly in dark mode
- tweak buzzer scoreboard styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683f4cc07da88320864a63218ec2af41