### PR TITLE
Add return link to dashboard at top of shop

### DIFF
--- a/shop.html
+++ b/shop.html
@@ -89,6 +89,11 @@
       🌙 / ☀️
     </button>
   </div>
+  <div class="fixed top-4 left-4 z-50">
+    <a href="dashboard.html" class="bg-green-600 hover:bg-green-700 text-white font-bold py-1 px-3 rounded-full shadow text-sm">
+      ⬅️ Zurück zum Dashboard
+    </a>
+  </div>
   <div class="shop-container w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
 
     <div id="loader" class="fixed inset-0 bg-white bg-opacity-70 flex items-center justify-center hidden z-50 dark:bg-gray-900 dark:bg-opacity-70">


### PR DESCRIPTION
## Summary
- add small fixed link for returning to the dashboard at the top of `shop.html`

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_683f4f13a1e88320bf5d0e6c89c90a98