### PR TITLE
Improve round start error handling

### DIFF
--- a/buzzer.html
+++ b/buzzer.html
@@ -424,21 +424,30 @@
       registrationInterval = null;
       signupTimer.textContent = '';
 
-      const { data, error } = await adminClient.from('buzzer_rounds')
-        .insert({ bet, point_limit: limit, start_time: new Date().toISOString(), active: true })
-        .select()
-        .single();
-      if (error) {
-        const msg = error.message || error.details || JSON.stringify(error);
-        console.error('Fehler beim Starten der Runde:', error);
+      try {
+        const { data, error } = await adminClient
+          .from('buzzer_rounds')
+          .insert({ bet, point_limit: limit, start_time: new Date().toISOString(), active: true })
+          .select()
+          .single();
+
+        if (error) {
+          const msg = error.message || error.details || error.hint || error.code || 'Unbekannter Fehler';
+          console.error('Fehler beim Starten der Runde:', error);
+          alert(`Fehler beim Starten der Runde: ${msg}`);
+          return;
+        }
+
+        await adminClient.from('scores').update({ points: 0 }).not('user_id', 'is', null);
+        activeRound = data;
+        signedUp = false;
+        startRoundModal.classList.add('hidden');
+        updateRoundUI();
+      } catch (err) {
+        const msg = err.message || 'Unbekannter Fehler';
+        console.error('Fehler beim Starten der Runde:', err);
         alert(`Fehler beim Starten der Runde: ${msg}`);
-        return;
       }
-      await adminClient.from('scores').update({ points: 0 }).not('user_id', 'is', null);
-      activeRound = data;
-      signedUp = false;
-      startRoundModal.classList.add('hidden');
-      updateRoundUI();
     }
 
     async function signupForRound() {


### PR DESCRIPTION
## Summary
- handle errors in `startRound` using try/catch
- show more informative messages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_683f61c4de648320b17a544311a306f9