### PR TITLE
Adjust dark mode toggle positioning

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -44,9 +44,9 @@
 <body class="bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-white">
 
   <!-- Dark Mode Schalter -->
-  <div class="fixed top-4 right-4 z-50">
-    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
-      🌙 / ☀️
+  <div class="fixed bottom-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300/75 dark:bg-gray-700/75 text-black dark:text-white p-2 rounded-full shadow opacity-70 hover:opacity-100 transition">
+      🌙
     </button>
   </div>
 

--- a/buzzer.html
+++ b/buzzer.html
@@ -29,9 +29,9 @@
   </style>
 </head>
 <body class="flex flex-col items-center justify-center min-h-screen bg-green-100 text-green-900 font-sans space-y-6 px-4 dark:bg-gray-900 dark:text-white">
-  <div class="fixed top-4 right-4 z-50">
-    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
-      🌙 / ☀️
+  <div class="fixed bottom-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300/75 dark:bg-gray-700/75 text-black dark:text-white p-2 rounded-full shadow opacity-70 hover:opacity-100 transition">
+      🌙
     </button>
   </div>
   <h1 class="text-3xl font-bold mt-6 sm:mt-8">🔔 Buzzer</h1>

--- a/dashboard.html
+++ b/dashboard.html
@@ -47,9 +47,9 @@
   </style>
 </head>
 <body class="flex items-center justify-center min-h-screen text-green-900 dark:bg-gray-900 dark:text-white">
-  <div class="fixed top-4 right-4 z-50">
-    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
-      🌙 / ☀️
+  <div class="fixed bottom-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300/75 dark:bg-gray-700/75 text-black dark:text-white p-2 rounded-full shadow opacity-70 hover:opacity-100 transition">
+      🌙
     </button>
   </div>
   <div class="text-center p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect space-y-6">

--- a/index.html
+++ b/index.html
@@ -55,9 +55,9 @@
   </style>
 </head>
 <body class="text-green-900 relative dark:bg-gray-900 dark:text-white">
-  <div class="fixed top-4 right-4 z-50">
-    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
-      🌙 / ☀️
+  <div class="fixed bottom-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300/75 dark:bg-gray-700/75 text-black dark:text-white p-2 rounded-full shadow opacity-70 hover:opacity-100 transition">
+      🌙
     </button>
   </div>
   <div class="w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">

--- a/mentos.html
+++ b/mentos.html
@@ -36,9 +36,9 @@
   </style>
 </head>
 <body class="text-green-900 relative dark:bg-gray-900 dark:text-white">
-  <div class="fixed top-4 right-4 z-50">
-    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
-      🌙 / ☀️
+  <div class="fixed bottom-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300/75 dark:bg-gray-700/75 text-black dark:text-white p-2 rounded-full shadow opacity-70 hover:opacity-100 transition">
+      🌙
     </button>
   </div>
 

--- a/shop.html
+++ b/shop.html
@@ -84,9 +84,9 @@
   </style>
 </head>
 <body class="text-green-900 relative dark:bg-gray-900 dark:text-white">
-  <div class="fixed top-4 right-4 z-50">
-    <button onclick="toggleDarkMode()" class="bg-gray-300 dark:bg-gray-700 text-black dark:text-white px-4 py-2 rounded shadow">
-      🌙 / ☀️
+  <div class="fixed bottom-4 right-4 z-50">
+    <button onclick="toggleDarkMode()" class="bg-gray-300/75 dark:bg-gray-700/75 text-black dark:text-white p-2 rounded-full shadow opacity-70 hover:opacity-100 transition">
+      🌙
     </button>
   </div>
   <div class="fixed top-4 left-4 z-50">


### PR DESCRIPTION
## Summary
- move dark mode toggle to bottom right across all pages
- make toggle smaller and semi-transparent so it interferes less with the UI

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6840791dd31483208ccf7fce8541a0cd