### PR TITLE
Quantity selector and buy button inline

### DIFF
--- a/shop.html
+++ b/shop.html
@@ -234,7 +234,7 @@ async function loadCategories() {
           </p>
         </div>
         ${product.stock > 0 ?
-          `<div class="flex flex-col sm:flex-row items-center gap-2">
+          `<div class="flex items-center gap-2">
             <input type="number" min="1" max="${product.stock}" value="1" id="qty-${product.id}" class="w-14 border border-gray-300 rounded px-2 py-1 text-sm dark:bg-gray-700 dark:text-white dark:border-gray-600">
             <button class="bg-green-600 text-white text-sm px-3 py-1 rounded-md shadow hover:bg-green-700 transition" onclick="buyProduct('${product.id}', 'qty-${product.id}', '${product.name}', ${product.price})">Kaufen</button>
           </div>` : ''


### PR DESCRIPTION
## Summary
- simplify product quantity control layout so the quantity input and the buy button are inline on all screen sizes

## Testing
- `grep -n "flex items-center" -n shop.html | head`

------
https://chatgpt.com/codex/tasks/task_b_68408f0d1e8c8320907edc735eaf487e