### PR TITLE
Set dark mode as default

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -199,7 +199,8 @@ function toggleSection(id) {
   if (el) el.classList.toggle('hidden');
 }
 
-if (localStorage.getItem('darkMode') === 'true') {
+// Darkmode standardmäßig aktiv lassen, sofern nicht abgeschaltet
+if (localStorage.getItem('darkMode') !== 'false') {
   document.documentElement.classList.add('dark');
 }
 

--- a/buzzer.html
+++ b/buzzer.html
@@ -151,7 +151,8 @@
       const isDark = document.documentElement.classList.toggle('dark');
       localStorage.setItem('darkMode', isDark ? 'true' : 'false');
     }
-    if (localStorage.getItem('darkMode') === 'true') {
+    // Darkmode ist standardmäßig aktiv
+    if (localStorage.getItem('darkMode') !== 'false') {
       document.documentElement.classList.add('dark');
     }
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -67,7 +67,8 @@
       const isDark = document.documentElement.classList.toggle('dark');
       localStorage.setItem('darkMode', isDark ? 'true' : 'false');
     }
-    if (localStorage.getItem('darkMode') === 'true') {
+    // Darkmode standardmäßig aktiv, sofern nicht deaktiviert
+    if (localStorage.getItem('darkMode') !== 'false') {
       document.documentElement.classList.add('dark');
     }
 

--- a/index.html
+++ b/index.html
@@ -92,7 +92,8 @@
       const isDark = document.documentElement.classList.toggle('dark');
       localStorage.setItem('darkMode', isDark ? 'true' : 'false');
     }
-    if (localStorage.getItem('darkMode') === 'true') {
+    // Standardmäßig Darkmode aktivieren, außer der Nutzer hat ihn deaktiviert
+    if (localStorage.getItem('darkMode') !== 'false') {
       document.documentElement.classList.add('dark');
     }
 

--- a/mentos.html
+++ b/mentos.html
@@ -81,7 +81,8 @@
       const isDark = document.documentElement.classList.toggle('dark');
       localStorage.setItem('darkMode', isDark ? 'true' : 'false');
     }
-    if (localStorage.getItem('darkMode') === 'true') {
+    // Darkmode ist nun die Voreinstellung
+    if (localStorage.getItem('darkMode') !== 'false') {
       document.documentElement.classList.add('dark');
     }
 

--- a/shop.html
+++ b/shop.html
@@ -139,7 +139,8 @@
       const isDark = document.documentElement.classList.toggle('dark');
       localStorage.setItem('darkMode', isDark ? 'true' : 'false');
     }
-    if (localStorage.getItem('darkMode') === 'true') {
+    // Darkmode bleibt aktiv, solange der Nutzer ihn nicht deaktiviert
+    if (localStorage.getItem('darkMode') !== 'false') {
       document.documentElement.classList.add('dark');
     }
 


### PR DESCRIPTION
## Summary
- activate dark mode by default across all pages
- keep existing toggle so users can disable it

## Testing
- `true` (no tests present)


------
https://chatgpt.com/codex/tasks/task_b_68408fea2c00832098c20d8b48c05abd