### PR TITLE
Fix Mentos dashboard button position

### DIFF
--- a/mentos.html
+++ b/mentos.html
@@ -42,6 +42,12 @@
     </button>
   </div>
 
+  <div class="fixed top-4 left-4 z-50">
+    <a href="dashboard.html" class="bg-green-600 hover:bg-green-700 text-white font-bold py-1 px-3 rounded-full shadow text-sm">
+      ⬅️ Zurück zum Dashboard
+    </a>
+  </div>
+
   <div class="w-full px-3 py-2 max-w-screen-sm mx-auto mt-12 sm:mt-20 p-6 sm:p-10 rounded-3xl kiffer-shadow border-4 border-green-300 glass-effect animate-fade-in">
     <h1 class="text-3xl sm:text-4xl font-bold mb-6 text-center text-green-800">Mentos 🐱</h1>
     <h2 class="text-xl text-center">Letzte Fütterung vor:</h2>
@@ -69,11 +75,6 @@
       </table>
     </div>
 
-    <div class="text-center mt-8">
-      <a href="dashboard.html" class="inline-block bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full shadow">
-        ⬅️ Zurück zum Dashboard
-      </a>
-    </div>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- add fixed top-left dashboard button on `mentos.html`
- remove old bottom positioned button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6840905e87cc8320926a905a721792f0