### PR TITLE
Update dashboard back buttons

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -50,6 +50,12 @@
     </button>
   </div>
 
+  <div class="fixed top-4 left-4 z-50">
+    <a href="dashboard.html" class="bg-green-600 hover:bg-green-700 text-white font-bold py-1 px-3 rounded-full shadow text-sm">
+      ⬅️ Zurück zum Dashboard
+    </a>
+  </div>
+
   <div class="w-full px-3 py-4 sm:py-6 max-w-screen-lg mx-auto mt-6 sm:mt-8 p-4 sm:p-6 bg-white dark:bg-gray-800 rounded-xl shadow-lg">
     <h1 class="text-xl sm:text-2xl font-semibold mb-6 text-center">Adminbereich – Rischis Kiosk</h1>
 
@@ -498,11 +504,6 @@ function loadMorePurchases() {
   loadPurchases(false);
 }
 
-  </script>
-  <div class="text-center mt-8">
-  <a href="dashboard.html" class="inline-block bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full shadow">
-    ⬅️ Zurück zum Dashboard
-  </a>
-</div>
+</script>
 </body>
 </html>

--- a/buzzer.html
+++ b/buzzer.html
@@ -34,6 +34,12 @@
       🌙
     </button>
   </div>
+
+  <div class="fixed top-4 left-4 z-50">
+    <a href="dashboard.html" class="bg-green-600 hover:bg-green-700 text-white font-bold py-1 px-3 rounded-full shadow text-sm">
+      ⬅️ Zurück zum Dashboard
+    </a>
+  </div>
   <h1 class="text-3xl font-bold mt-6 sm:mt-8">🔔 Buzzer</h1>
   <audio id="buzz-sound" src="buzz.wav" preload="auto"></audio>
 
@@ -138,12 +144,6 @@
   <div id="history" class="w-full max-w-xs sm:max-w-md mt-8 bg-white shadow rounded p-4 text-sm sm:text-base overflow-x-auto dark:bg-gray-800">
     <h2 class="text-lg sm:text-xl font-bold mb-4 text-center">📜 Spielverlauf</h2>
     <div id="history-body" class="space-y-4"></div>
-  </div>
-
-  <div class="text-center mt-8 mb-8">
-    <a href="dashboard.html" class="inline-block bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full shadow">
-      ⬅️ Zurück zum Dashboard
-    </a>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- move `Zurück zum Dashboard` link to the top-left corner on Admin and Buzzer pages
- remove the old button from the bottom of both pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6840917e44cc8320b955471bb8c8797a