### PR TITLE
Handle old point_limit name on buzzer

### DIFF
--- a/buzzer.html
+++ b/buzzer.html
@@ -346,7 +346,8 @@
           .select('points')
           .eq('user_id', currentBuzz.user_id)
           .single();
-        if (activeRound && score && score.points >= activeRound.points_limit) {
+        const roundLimit = activeRound?.points_limit ?? activeRound?.point_limit;
+        if (activeRound && score && typeof roundLimit === 'number' && score.points >= roundLimit) {
           await endRound(currentBuzz.user_id, currentBuzz.username);
         }
         await resetBuzzer();


### PR DESCRIPTION
## Summary
- allow fallback to `point_limit` when checking the round limit
- still insert using the new `points_limit` column

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68409f0fffc48320b7457119092f2c37