### PR TITLE
Fix admin detection in buzzer.html

### DIFF
--- a/buzzer.html
+++ b/buzzer.html
@@ -222,14 +222,14 @@
 
       const { data: profile } = await supabase
         .from("users")
-        .select("rule, username")
+        .select("role, username")
         .eq("id", currentUser.id)
         .single();
 
       if (!profile) return;
 
       currentUser.name = profile.username;
-      currentUser.role = profile.rule;
+      currentUser.role = profile.role;
 
       if (currentUser.role === 'admin') {
         roundControls.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- fix user role lookup in buzzer.html so the reset button appears for admins

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_6840a435771083208ee6f2b39d253e21