### PR TITLE
Fix buzzer round detection

### DIFF
--- a/buzzer.html
+++ b/buzzer.html
@@ -516,7 +516,15 @@
         .order('start_time', { ascending: false })
         .limit(1)
         .single();
-      activeRound = latest || null;
+
+      let finishedRound = null;
+      if (latest && (latest.active || latest.winner_id === null)) {
+        activeRound = latest;
+      } else {
+        activeRound = null;
+        finishedRound = latest;
+      }
+
       if (activeRound) {
         let existing = null;
         if (currentUser) {
@@ -535,12 +543,7 @@
       } else {
         signedUp = false;
         participantList.textContent = '';
-        const { data: lastRound } = await supabase
-          .from('buzzer_rounds')
-          .select('id, bet, winner_id, active')
-          .order('start_time', { ascending: false })
-          .limit(1)
-          .single();
+        const lastRound = finishedRound;
         if (lastRound && !lastRound.active && lastRound.winner_id) {
           const { data: winner } = await supabase
             .from('users')


### PR DESCRIPTION
## Summary
- fix detection of active buzzer rounds so admins can start new rounds

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6840a8fec6688320bab5489bbcd2fc52