### PR TITLE
Fix buzzer loading

### DIFF
--- a/buzzer.html
+++ b/buzzer.html
@@ -298,7 +298,7 @@
         .eq("active", true)
         .order("timestamp", { ascending: true })
         .limit(1)
-        .single();
+        .maybeSingle();
       if (error) {
         console.error('Fehler beim Laden des Buzzers:', error.message);
         showError('Fehler beim Laden des Buzzers');
@@ -549,7 +549,7 @@
         .select('*')
         .order('start_time', { ascending: false })
         .limit(1)
-        .single();
+        .maybeSingle();
 
       if (roundErr) {
         console.error('Fehler beim Laden der aktuellen Runde:', roundErr.message);


### PR DESCRIPTION
## Summary
- don't error when there are no rows for buzzer or round

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_b_6840b06be5b08320822d88eb854f382d