### PR TITLE
Show recent purchases first

### DIFF
--- a/shop.html
+++ b/shop.html
@@ -118,8 +118,9 @@
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0"
     );
 
-    let currentUser = null;
-    let userBalance = 0;
+      let currentUser = null;
+      let userBalance = 0;
+      let sortUsed = false;
 
     function showMessage(text, type = 'info') {
       const el = document.getElementById('message');
@@ -182,35 +183,57 @@ async function loadCategories() {
         : 'text-green-600 dark:text-green-400 font-bold';
     }
 
-    async function loadProducts() {
-  showLoader();
-  const searchTerm = document.getElementById('search')?.value?.toLowerCase() || '';
-  const selectedCategory = document.getElementById('category-filter')?.value || '';
-  const sortOption = document.getElementById('sort-products')?.value || 'price_asc';
+      async function loadProducts() {
+    showLoader();
+    const searchTerm = document.getElementById('search')?.value?.toLowerCase() || '';
+    const selectedCategory = document.getElementById('category-filter')?.value || '';
+    const sortOption = document.getElementById('sort-products')?.value || 'price_asc';
 
-  let query = supabase.from('products').select('*').eq('available', true);
-  if (selectedCategory) {
-    query = query.eq('category', selectedCategory);
-  }
+    let query = supabase.from('products').select('*').eq('available', true);
+    if (selectedCategory) {
+      query = query.eq('category', selectedCategory);
+    }
 
-  if (sortOption === 'price_desc') {
-    query = query.order('price', { ascending: false });
-  } else {
-    query = query.order('price', { ascending: true });
-  }
+    if (sortOption === 'price_desc') {
+      query = query.order('price', { ascending: false });
+    } else {
+      query = query.order('price', { ascending: true });
+    }
 
-  const { data: products, error } = await query;
-  const list = document.getElementById('product-list');
-  list.innerHTML = '';
-  hideLoader();
+    const { data: products, error } = await query;
+    const list = document.getElementById('product-list');
+    list.innerHTML = '';
+    hideLoader();
 
-  if (error || !products) {
-    return showMessage("Fehler beim Laden der Produkte.", 'error');
-  }
+    if (error || !products) {
+      return showMessage("Fehler beim Laden der Produkte.", 'error');
+    }
 
-  products
-  .filter(p => p.name.toLowerCase().includes(searchTerm))
-  .forEach(product => {
+    let filtered = products.filter(p => p.name.toLowerCase().includes(searchTerm));
+
+    if (!sortUsed && currentUser?.id) {
+      const { data: recent } = await supabase
+        .from('purchases')
+        .select('product_id')
+        .eq('user_id', currentUser.id)
+        .order('created_at', { ascending: false })
+        .limit(5);
+
+      if (recent) {
+        const ids = [];
+        recent.forEach(r => { if (!ids.includes(r.product_id)) ids.push(r.product_id); });
+        filtered.sort((a, b) => {
+          const ia = ids.indexOf(a.id);
+          const ib = ids.indexOf(b.id);
+          if (ia === -1 && ib === -1) return 0;
+          if (ia === -1) return 1;
+          if (ib === -1) return -1;
+          return ia - ib;
+        });
+      }
+    }
+
+    filtered.forEach(product => {
     const li = document.createElement('li');
     li.className = 'border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 p-3 rounded-lg shadow-md hover:shadow-lg transition text-gray-800 dark:text-white';
 
@@ -336,7 +359,10 @@ async function loadCategories() {
 
     document.getElementById('search').addEventListener('input', loadProducts);
     document.getElementById('category-filter').addEventListener('change', loadProducts);
-    document.getElementById('sort-products').addEventListener('change', loadProducts);
+      document.getElementById('sort-products').addEventListener('change', () => {
+        sortUsed = true;
+        loadProducts();
+      });
     document.getElementById('sort-history').addEventListener('change', loadPurchaseHistory);
   </script>
   </body>


### PR DESCRIPTION
## Summary
- display each user's recently purchased items at the top of the shop list
- keep standard price ordering when user explicitly sorts products

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6841d2a79dc883209aaccf7008f2f4b7