### PR TITLE
Implement user activity timestamp updates

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -9,6 +9,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <script src="session.js"></script>
 <script>
   tailwind.config = { darkMode: 'class' };
 </script>
@@ -219,6 +220,10 @@ if (localStorage.getItem('darkMode') !== 'false') {
       "https://izkuiqjhzeeirmcikbef.supabase.co",
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0ODgwMDA5NCwiZXhwIjoyMDY0Mzc2MDk0fQ.yF2-AKGKcHFNpkIt-bg-YMhWjjLK74cLw6t3VfjDl8w"
     );
+
+    supabase.auth.getUser().then(({ data }) => {
+      if (data?.user) setupActivityTracking(data.user.id);
+    });
 
     // Produkt hinzufügen
     document.getElementById('add-product').addEventListener('submit', async (e) => {

--- a/buzzer.html
+++ b/buzzer.html
@@ -9,6 +9,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <script src="session.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Comfortaa&display=swap" rel="stylesheet">
   <style>
     body {
@@ -83,6 +84,7 @@
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return window.location.href = 'index.html';
     currentUser = user;
+    setupActivityTracking(user.id);
     const { data: profile } = await supabase.from('users').select('role,balance').eq('id', user.id).single();
     currentRole = profile?.role;
     checkAdmin();

--- a/dashboard.html
+++ b/dashboard.html
@@ -9,6 +9,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <script src="session.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Comfortaa&family=Rock+Salt&display=swap" rel="stylesheet">
   <style>
     body {
@@ -80,6 +81,7 @@
     supabase.auth.getUser().then(async ({ data }) => {
       if (!data?.user) return window.location.href = "index.html";
 
+      setupActivityTracking(data.user.id);
       const { data: profile } = await supabase.from('users').select('role').eq('id', data.user.id).single();
       if (profile?.role === 'admin') {
         document.getElementById('admin-btn').classList.remove('hidden');

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <script src="session.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Comfortaa&family=Rock+Salt&display=swap" rel="stylesheet">
   <style>
     body {
@@ -145,6 +146,7 @@
       if (error) return showMessage("Login fehlgeschlagen: " + error.message);
 
       await createUserIfNotExists(data.user);
+      setupActivityTracking(data.user.id);
       showMessage("Login erfolgreich! Weiterleitung...", true);
 
       setTimeout(() => {

--- a/mentos.html
+++ b/mentos.html
@@ -9,6 +9,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <script src="session.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@700&display=swap" rel="stylesheet">
   <style>
     body {
@@ -100,6 +101,7 @@
 
     supabase.auth.getUser().then(async ({ data }) => {
       if (!data?.user) return;
+      setupActivityTracking(data.user.id);
       const { data: profile } = await supabase
         .from('users')
         .select('role')

--- a/session.js
+++ b/session.js
@@ -1,0 +1,17 @@
+function getBerlinTimestamp() {
+  const berlinString = new Date().toLocaleString('en-US', { timeZone: 'Europe/Berlin' });
+  return new Date(berlinString).toISOString();
+}
+
+async function updateLastActive(userId) {
+  if (!userId || !window.supabase) return;
+  const timestamp = getBerlinTimestamp();
+  await supabase.from('user_sessions').upsert({ user_id: userId, last_active: timestamp });
+}
+
+function setupActivityTracking(userId) {
+  const events = ['mousemove', 'keydown', 'click', 'touchstart'];
+  const handler = () => updateLastActive(userId);
+  events.forEach(event => document.addEventListener(event, handler));
+  updateLastActive(userId);
+}

--- a/shop.html
+++ b/shop.html
@@ -14,6 +14,7 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <script src="session.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body {
@@ -170,6 +171,7 @@ async function loadCategories() {
       const { data: { user }, error } = await supabase.auth.getUser();
       if (error || !user) return showMessage("Fehler beim Laden des Nutzers.", 'error');
       currentUser = user;
+      setupActivityTracking(user.id);
       document.getElementById('user-email').textContent = user.email;
 
       const { data, error: balanceError } = await supabase.from('users').select('balance').eq('id', user.id).single();


### PR DESCRIPTION
## Summary
- add `session.js` with helper to update `user_sessions.last_active`
- load and use activity tracking on login and pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6841d918da2483209912586d87e09ce4