### PR TITLE
Add online user list to buzzer page

### DIFF
--- a/buzzer.html
+++ b/buzzer.html
@@ -1,1 +1,89 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="Rischis Kiosk">
+  <meta name="format-detection" content="telephone=no">
+  <meta name="theme-color" content="#0f172a">
+  <title>Buzzer</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = { darkMode: 'class' };</script>
+  <script src="https://unpkg.com/@supabase/supabase-js"></script>
+  <script src="session.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@700&display=swap" rel="stylesheet">
+  <style>
+    html { background: linear-gradient(135deg, #d1fae5, #a7f3d0, #6ee7b7); }
+    html.dark { background: linear-gradient(135deg, #0f172a, #1e293b, #334155); color-scheme: dark; }
+    body { font-family: 'Inter', sans-serif; max-width: 100vw; overflow-x: hidden; -webkit-overflow-scrolling: touch; padding-top: env(safe-area-inset-top); padding-right: env(safe-area-inset-right); padding-bottom: env(safe-area-inset-bottom); padding-left: env(safe-area-inset-left); }
+    h1 { font-family: 'Poppins', sans-serif; }
+  </style>
+</head>
+<body class="text-green-900 dark:text-white">
+  <div id="online-users" class="text-center py-2 bg-green-200 dark:bg-green-700 text-green-900 dark:text-white shadow">
+    Online: -
+  </div>
+  <div class="flex items-center justify-center mt-20">
+    <button id="buzzer" class="bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-6 px-12 rounded-full text-4xl shadow-lg">🔔</button>
+  </div>
 
+  <audio id="buzz-sound" src="buzz.wav" preload="auto"></audio>
+
+  <script>
+    function toggleDarkMode() {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('darkMode', isDark ? 'true' : 'false');
+    }
+    if (localStorage.getItem('darkMode') !== 'false') {
+      document.documentElement.classList.add('dark');
+    }
+
+    const supabase = window.supabase.createClient(
+      "https://izkuiqjhzeeirmcikbef.supabase.co",
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml6a3VpcWpoemVlaXJtY2lrYmVmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4MDAwOTQsImV4cCI6MjA2NDM3NjA5NH0.mPu0jQYnt0uGoLgehNFDHZprEcmrzGJ667D31sLSbj0"
+    );
+
+    let currentUser = null;
+
+    async function updateSession() {
+      if (!currentUser) return;
+      await supabase
+        .from('user_sessions')
+        .upsert({
+          user_id: currentUser.id,
+          name: currentUser.user_metadata?.name || currentUser.email.split('@')[0],
+          online: true,
+          last_active: new Date().toISOString()
+        }, { onConflict: 'user_id' });
+    }
+
+    async function loadOnlineUsers() {
+      const { data } = await supabase
+        .from('user_sessions')
+        .select('name')
+        .eq('online', true);
+      const names = data ? data.map(u => u.name).join(', ') : '';
+      document.getElementById('online-users').textContent = 'Online: ' + (names || '-');
+    }
+
+    supabase.auth.getUser().then(async ({ data }) => {
+      if (!data?.user) return;
+      currentUser = data.user;
+      await updateSession();
+      loadOnlineUsers();
+      setInterval(() => { updateSession(); loadOnlineUsers(); }, 5000);
+    });
+
+    window.addEventListener('beforeunload', () => {
+      if (!currentUser) return;
+      supabase.from('user_sessions').update({ online: false }).eq('user_id', currentUser.id);
+    });
+
+    document.getElementById('buzzer').addEventListener('click', () => {
+      document.getElementById('buzz-sound').play();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement full `buzzer.html` page
- show currently online users via Supabase
- update `user_sessions` for the visiting user
- play `buzz.wav` on buzzer click

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68421b516980832e800500bdc75336d1